### PR TITLE
Fix: 메인페이지, 헤더 수입/지출 값 오류 (#33)

### DIFF
--- a/src/components/MonthAnalysis.vue
+++ b/src/components/MonthAnalysis.vue
@@ -10,9 +10,6 @@ import {
   renderChart,
 } from '@/utils/month-analysis.js';
 
-import axios from 'axios';
-import Chart from 'chart.js/auto';
-
 const userStore = useUserStore();
 
 const userId = userStore.userId;

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -128,11 +128,18 @@ const fetchTradeTotal = async (userId) => {
 
 // 월별 수입과 지출 계산
 const tradeSummary = computed(() => {
-  const income = tradeList.value
+  const selectedMonth = currentMonth.value; // getMonth()는 0부터 시작하므로 +1 필요
+
+  const filteredTrades = tradeList.value.filter((trade) => {
+    const [year, month] = trade.tradeDate.split('-').map(Number);
+    return month === selectedMonth;
+  });
+
+  const income = filteredTrades
     .filter((trade) => trade.tradeType === '수입')
     .reduce((sum, trade) => sum + trade.tradeAmount, 0);
 
-  const expense = tradeList.value
+  const expense = filteredTrades
     .filter((trade) => trade.tradeType === '지출')
     .reduce((sum, trade) => sum + trade.tradeAmount, 0);
 


### PR DESCRIPTION
## 구현한 기능
- 메인페이지 월 별 수입/지출 금액을 달마다 분류되도록 코드 수정
- 헤더 사이드바 이번달 총액을 실시간으로 받아오지 못하던 코드를 수정

## 코드 설명

```
watch(route, fetchUserTotalInfo);
```

- `Header` 가 `App.vue` 에서 외부에 `RouterView` 가 있어서 trade 값을 추가시키는 로직을 `watch` 나 `computed` 로 감지하지 못한다고 추정
- 그래서 페이지 이동(엔드포인트)이 있을때마다 다시 정보를 받아오도록 `watch` 코드를 작성