### PR TITLE
Feat: 소비 분석 페이지 분리

### DIFF
--- a/db.json
+++ b/db.json
@@ -43,25 +43,10 @@
     {
       "userId": "6",
       "email": "1@1",
-      "password": "2",
+      "password": "1",
       "nickname": "수정된닉네임",
       "age": "20",
       "id": "6d33"
-    },
-    {
-      "id": "6dbb",
-      "email": "22@12.com",
-      "password": "12",
-      "nickname": "12",
-      "age": 12
-    },
-    {
-      "id": "e588",
-      "email": "12@123.com",
-      "password": "12",
-      "nickname": "12",
-      "age": 12,
-      "userId": 1744248160806
     }
   ],
   "tradeList": [
@@ -205,17 +190,6 @@
       "id": "1d08"
     },
     {
-      "id": "1744188156272",
-      "tradeId": "1744188156272",
-      "tradeType": "지출",
-      "tradeDate": "2025-04-09",
-      "tradeAmount": 1000000000,
-      "tradeDescription": "rr",
-      "userId": "1",
-      "expenseCategory": "교통",
-      "tradeMethod": "신용카드"
-    },
-    {
       "id": "1744218411570",
       "tradeId": "1744218411570",
       "tradeType": "지출",
@@ -233,6 +207,26 @@
       "tradeDate": "2025-04-10",
       "tradeAmount": 100000,
       "tradeDescription": "test1",
+      "userId": "1",
+      "incomeCategory": "용돈"
+    },
+    {
+      "id": "1744252612183",
+      "tradeId": "1744252612183",
+      "tradeType": "수입",
+      "tradeDate": "2025-04-10",
+      "tradeAmount": 200000,
+      "tradeDescription": "",
+      "userId": "1",
+      "incomeCategory": "상여금"
+    },
+    {
+      "id": "1744252753704",
+      "tradeId": "1744252753704",
+      "tradeType": "수입",
+      "tradeDate": "2025-04-10",
+      "tradeAmount": 300000,
+      "tradeDescription": "333",
       "userId": "1",
       "incomeCategory": "용돈"
     }

--- a/db.json
+++ b/db.json
@@ -229,6 +229,39 @@
       "tradeDescription": "333",
       "userId": "1",
       "incomeCategory": "용돈"
+    },
+    {
+      "id": "1744258006697",
+      "tradeId": "1744258006697",
+      "tradeType": "지출",
+      "tradeDate": "2025-03-30",
+      "tradeAmount": 1000000,
+      "tradeDescription": "",
+      "userId": "1",
+      "expenseCategory": "보건",
+      "tradeMethod": "계좌이체"
+    },
+    {
+      "id": "1744258227475",
+      "tradeId": "1744258227475",
+      "tradeType": "지출",
+      "tradeDate": "2025-04-10",
+      "tradeAmount": 230000,
+      "tradeDescription": "",
+      "userId": "1",
+      "expenseCategory": "주거",
+      "tradeMethod": "신용카드"
+    },
+    {
+      "id": "1744258619870",
+      "tradeId": "1744258619870",
+      "tradeType": "지출",
+      "tradeDate": "2025-04-10",
+      "tradeAmount": 300000,
+      "tradeDescription": "",
+      "userId": "1",
+      "expenseCategory": "통신",
+      "tradeMethod": "계좌이체"
     }
   ],
   "tradeType": [

--- a/src/pages/Analysis.vue
+++ b/src/pages/Analysis.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="mt-5">
+    <!-- 월별 소비 분석 -->
+    <section class="analysis-section mb-4">
+      <h5 class="analysis-title">📆 월별 소비 분석</h5>
+      <div class="card p-4 border-0 shadow-sm rounded-4 bg-white">
+        <MonthAnalysis />
+      </div>
+    </section>
+
+    <!-- 카테고리 별 소비 분석 -->
+    <section class="analysis-section mb-4">
+      <h5 class="analysis-title">🗂️ 카테고리별 소비 분석</h5>
+      <div class="card p-4 border-0 shadow-sm rounded-4 bg-white">
+        <CategoryAnalysis />
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import CategoryAnalysis from '@/components/CategoryAnalysis.vue';
+import MonthAnalysis from '@/components/MonthAnalysis.vue';
+</script>
+
+<style scoped>
+.analysis-title {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #495057;
+  margin-bottom: 0.75rem;
+  padding-left: 0.25rem;
+}
+
+.analysis-section {
+  padding: 0 0.5rem;
+}
+</style>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -31,49 +31,15 @@
         </div>
       </div>
       <div class="text-end mt-3">
-        <button class="btn btn-outline-secondary btn-sm">분석 더 보기</button>
+        <button class="btn btn-outline-secondary btn-sm" @click="navToAnalysis">
+          분석 더 보기
+        </button>
       </div>
     </div>
 
     <!-- 달력 -->
     <Calender />
 
-    <!-- 분석 탭 -->
-    <div class="mt-4">
-      <div class="tabs mb-3">
-        <ul class="nav nav-tabs">
-          <li class="nav-item">
-            <a
-              class="nav-link"
-              :class="{ active: showMonthly }"
-              href="#"
-              @click.prevent="showMonthlyAnalysis"
-            >
-              월별 소비 분석
-            </a>
-          </li>
-          <li class="nav-item">
-            <a
-              class="nav-link"
-              :class="{ active: showCategory }"
-              href="#"
-              @click.prevent="showCategoryAnalysis"
-            >
-              카테고리 별 소비 분석
-            </a>
-          </li>
-        </ul>
-      </div>
-
-      <!-- 월 별 소비 분석 -->
-      <div v-if="showMonthly" class="list-group">
-        <MonthAnalysis />
-      </div>
-      <!-- 카테고리 별 소비 분석 -->
-      <div v-if="showCategory">
-        <CategoryAnalysis />
-      </div>
-    </div>
     <button
       class="btn btn-success btn-lg rounded-circle position-fixed fs-2 size-2 d-flex justify-content-center align-items-center z-3 shadow-sm"
       style="bottom: 3rem; right: 3rem"
@@ -217,6 +183,12 @@ const route = useRouter();
 // 거래 추가 페이지로 이동
 const navToTradeAdd = () => {
   route.push('/trade/add');
+};
+
+// 분석 페이지로 이동
+
+const navToAnalysis = () => {
+  route.push('/analysis');
 };
 
 onMounted(async () => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -55,7 +55,12 @@ const router = createRouter({
       name: 'editProfile',
       component: () => import('../pages/EditProfile.vue'),
     },
-
+    // 소비 분석 페이지
+    {
+      path: '/analysis',
+      name: 'analysis',
+      component: () => import('../pages/Analysis.vue'),
+    },
     // // Not Found
     // {
     //   path: '/:pathMatch(.*)*',


### PR DESCRIPTION
## 수정 사항
1. 분석 페이지 분리
2. 카테고리 분석에서 이전 달 소비 까지 포함되는 버그 수정
3. 페이지 새로 고침 시 카테고리 분석 데이터 날아가는 버그 수정

## 수정 화면
![image](https://github.com/user-attachments/assets/30477fd8-41c2-4cec-9546-5ef67fa45587)


## 추가 수정 예정 작업
1. UI 수정
2. 햄버거 버튼 open 시 분석 페이지로 이동 가능하도록 버튼 추가