### PR TITLE
feat: 뒤로가기 버튼 추가 #32

### DIFF
--- a/db.json
+++ b/db.json
@@ -210,16 +210,6 @@
       "userId": "1",
       "expenseCategory": "주거",
       "tradeMethod": "계좌이체"
-    },
-    {
-      "id": "1744243696052",
-      "tradeId": "1744243696052",
-      "tradeType": "수입",
-      "tradeDate": "2025-04-10",
-      "tradeAmount": 100000,
-      "tradeDescription": "test1",
-      "userId": "1",
-      "incomeCategory": "용돈"
     }
   ],
   "tradeType": [

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,6 +4,23 @@
     :class="{ 'bg-carrot': isHome, 'bg-white border-bottom': !isHome }"
   >
     <div class="container-fluid position-relative">
+      <!-- 뒤로가기 버튼 -->
+      <!-- <button
+        v-if="!isHome"
+        class="btn navbar-toggler"
+        :class="isHome ? 'back-button' : 'back-button'"
+        @click="goBack"
+      > -->
+      <!-- <i class="back-button"></i>
+      </button> -->
+
+      <button
+        v-if="isShowBackButton"
+        class="navbar-toggler me-auto"
+        @click="goBack"
+      >
+        <i class="back-button"></i>
+      </button>
       <!-- 중앙 타이틀 -->
       <RouterLink
         to="/"
@@ -140,12 +157,13 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, watch } from 'vue';
 import axios from 'axios';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useUserStore } from '@/stores/user-store';
 
 const route = useRoute();
+const router = useRouter();
 
 const userStore = useUserStore();
 
@@ -154,6 +172,26 @@ const isHome = computed(() => route.path === '/');
 // 현재 경로가 /login, /register 인지 확인해서 햄버거 버튼 숨김
 const showHamburger = computed(() => {
   return !['/login', '/register'].includes(route.path);
+});
+
+const isShowBackButton = computed(() => {
+  const path = route.path;
+  return (
+    path === '/trade' ||
+    path === '/trade/add' ||
+    path === '/profile/edit' ||
+    /^\/trade\/[^\/]+$/.test(path) || // '/trade/:id'
+    /^\/trade\/[^\/]+\/edit$/.test(path) // '/trade/:id/edit'
+  );
+});
+
+watch(isShowBackButton, (newValue, oldValue) => {
+  console.log(`${isShowBackButton.value} ${newValue}`);
+  if (newValue) {
+    console.log(`버튼 보여짐! ${isShowBackButton.value}`);
+  } else {
+    console.log(`안보임! ${isShowBackButton.value}`);
+  }
 });
 
 const isNavShow = ref(false);
@@ -222,6 +260,10 @@ const monthlyTotalColorClass = computed(() => {
 const handleLogout = () => {
   closeOffcanvas();
   userStore.logout();
+};
+
+const goBack = () => {
+  router.back();
 };
 </script>
 
@@ -295,5 +337,15 @@ const handleLogout = () => {
 }
 .pointer {
   cursor: pointer;
+}
+.back-button {
+  display: inline-block;
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: middle;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23ff8a3d' d='M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 100%;
 }
 </style>

--- a/src/pages/TradeList.vue
+++ b/src/pages/TradeList.vue
@@ -191,7 +191,7 @@ const route = useRouter();
 onMounted(() => {
   tradeStore.fetchTradeList(); // id 필터링 된 tradeList 가져오기(tradeStore.tradeList)
   userStore.hydrate(); // 세션에서 사용자 정보 불러오기
-  console.log('userId:', userStore.userId); // state 사용
+  // console.log('userId:', userStore.userId); // state 사용
   fetchIncomeList(); // 수입 리스트 가져오기
   fetchExpenseList(); // 지출 리스트 가져오기
 });
@@ -212,7 +212,7 @@ const formatDate = (date) => {
 const fetchIncomeList = async () => {
   try {
     const response = await axios.get(incomeUrlPrefix);
-    console.log(response.data);
+    // console.log(response.data);
     incomeList.value = response.data;
   } catch (err) {
     console.log(err);
@@ -223,7 +223,7 @@ const fetchIncomeList = async () => {
 const fetchExpenseList = async () => {
   try {
     const response = await axios.get(expenseUrlPrefix);
-    console.log(response.data);
+    // console.log(response.data);
     expenseList.value = response.data;
   } catch (err) {
     console.log(err);

--- a/src/stores/trade-store.js
+++ b/src/stores/trade-store.js
@@ -12,7 +12,7 @@ export const useTradeStore = defineStore('trade', () => {
   const fetchTradeList = async () => {
     try {
       const response = await axios.get(tradeUrlPrefix);
-      console.log(response.data);
+      // console.log(response.data);
 
       // userId가 일치하는 항목만 필터링
       tradeList.value = response.data.filter(


### PR DESCRIPTION
# 화면
![image](https://github.com/user-attachments/assets/8fcf2144-8743-4390-befe-13b4ac847f8b)

---
# 구현 내용
![image](https://github.com/user-attachments/assets/2dd67a69-b303-43a0-b5db-0844286692e6)

### 뒤로가기 필요한 경로 파악 및 정규식으로 라우팅 정의
1. /trade                  -> 전체 거래 리스트
2. /trade/:id             -> 거래 상세 조희
3. /trade/:id/edit     -> 거래 항목 수정
4. /trade/add          -> 거래 항목 추가
5. /profile/edit        -> 개인 정보 수정

### 버튼의 색상, 크기, 형식 등 기존의 햄버거 버튼과 통일

---
라우팅이 추가적으로 필요한 곳이나 뒤로가기 아이콘에 대한 피드백 있으면 알려주세요!

